### PR TITLE
kern/riscv/efi/init: Use time register in grub_efi_get_time_ms()

### DIFF
--- a/grub-core/kern/riscv/efi/init.c
+++ b/grub-core/kern/riscv/efi/init.c
@@ -33,16 +33,15 @@ grub_efi_get_time_ms (void)
   grub_uint64_t tmr;
 
 #if __riscv_xlen == 64
-  asm volatile ("rdcycle %0" : "=r" (tmr));
+  asm volatile ("rdtime %0" : "=r"(tmr));
 #else
   grub_uint32_t lo, hi, tmp;
-  asm volatile (
-    "1:\n"
-    "rdcycleh %0\n"
-    "rdcycle %1\n"
-    "rdcycleh %2\n"
-    "bne %0, %2, 1b"
-    : "=&r" (hi), "=&r" (lo), "=&r" (tmp));
+  asm volatile ("1:\n"
+                "rdtimeh %0\n"
+                "rdtime %1\n"
+                "rdtimeh %2\n"
+                "bne %0, %2, 1b"
+                : "=&r" (hi), "=&r" (lo), "=&r" (tmp));
   tmr = ((grub_uint64_t)hi << 32) | lo;
 #endif
 


### PR DESCRIPTION
The cycle register is not guaranteed to count at constant frequency. If it is counting at all depends on the state the performance monitoring unit. Use the time register to measure time.


Reviewed-by: Daniel Kiper <daniel.kiper@oracle.com>
(cherry picked from commit c5ae124e11f28f637cbd38cb4d6c1b9817baa135)